### PR TITLE
Add a balance check to the flash mint and test

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -79,10 +79,11 @@ contract DssFlash {
 
         vat.suck(address(this), _receiver, _amount);
         uint256 fee = rmul(_amount, toll);
+        uint256 bal = vat.dai(address(this));
 
         receiver.execute(_amount, fee, _data);
 
-        require(vat.dai(address(this)) == add(_amount, fee), "DssFlash/invalid-payback");
+        require(vat.dai(address(this)) == add(bal, add(_amount, fee)), "DssFlash/invalid-payback");
 
         vat.heal(_amount);
         vat.move(address(this), vow, fee);

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -74,7 +74,7 @@ contract TestMintAndPaybackReceiver is IFlashMintReceiver {
     }
 
     function execute(uint256 _amount, uint256 _fee, bytes calldata _params) external override {
-        // Mint 
+        // Mint
         vat.mint(address(this), mintRad);
         vat.move(address(this), address(flash), _amount + _fee);
     }
@@ -98,7 +98,7 @@ contract TestMintAndPaybackAllReceiver is IFlashMintReceiver {
     }
 
     function execute(uint256 _amount, uint256 _fee, bytes calldata _params) external override {
-        // Mint 
+        // Mint
         vat.mint(address(this), mintRad);
         vat.move(address(this), address(flash), _amount + mintRad);
     }
@@ -237,6 +237,20 @@ contract DssFlashTest is DSTest {
         assertEq(vat.dai(address(mintAndPaybackReceiver)), 9 ether);
     }
 
+    // Test mint doesn't fail when contract already has a Dai balance
+    function test_preexisting_dai_in_flash () public {
+        flash.file("toll", RATE_ONE_PCT);
+
+        vat.move(address(this), address(mintAndPaybackReceiver), rad(1 ether));
+
+        mintAndPaybackReceiver.setMint(10 ether);
+
+        flash.mint(address(mintAndPaybackReceiver), 100 ether, msg.data);
+
+        assertEq(vow.Joy(), 1 ether);
+        assertEq(vat.dai(address(mintAndPaybackReceiver)), rad(1 ether) + 9 ether);
+    }
+
     // test execute that return vat.dai() < add(_amount, fee) fails
     function testFail_mint_insufficient_dai () public {
         flash.file("toll", 5 * RATE_ONE_PCT);
@@ -253,10 +267,12 @@ contract DssFlashTest is DSTest {
         flash.mint(address(mintAndPaybackAllReceiver), 100 ether, msg.data);
     }
 
+
+
     // TODO:
     //       - Simple flash mint that uses a DEX
     //           - should test
     //       - Flash mint that moves DAI around in core without DaiJoin.exit()
     //           - should test
-    
+
 }

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -241,14 +241,17 @@ contract DssFlashTest is DSTest {
     function test_preexisting_dai_in_flash () public {
         flash.file("toll", RATE_ONE_PCT);
 
-        vat.move(address(this), address(mintAndPaybackReceiver), rad(1 ether));
+        // Move some collateral to the flash so it preexists the loan
+        vat.move(address(this), address(flash), rad(1 ether));
 
         mintAndPaybackReceiver.setMint(10 ether);
 
         flash.mint(address(mintAndPaybackReceiver), 100 ether, msg.data);
 
         assertEq(vow.Joy(), 1 ether);
-        assertEq(vat.dai(address(mintAndPaybackReceiver)), rad(1 ether) + 9 ether);
+        assertEq(vat.dai(address(mintAndPaybackReceiver)), 9 ether);
+        // Ensure preexistin amount remains in flash
+        assertEq(vat.dai(address(flash)), rad(1 ether));
     }
 
     // test execute that return vat.dai() < add(_amount, fee) fails


### PR DESCRIPTION
Was thinking about our earlier discussion about the assertion after the mint and realized that the contract could get locked if someone moves Dai to the module's vat balance outside of the mint.

This adds a pre- and post-mint balance check and test to assure that the correct amount is repaid, but won't lock the contract if there's a pre-existing balance. I'll note that a side-effect of this is that if there is a balance in there, it's basically stuck forever. In any case, for that to happen, someone would need to `vat.move()` it in there, so it's not likely to happen accidentally.

One other thing I'd add is that most of the tests are using `ether` values at `WAD` precision instead of `RAD`-precision values when interacting with the vat. Since tests end up being used as documentation for most of the dss contracts, you may want to update them to use `RAD` precision variables where applicable.