### PR TITLE
refactor: changed execute() to onFlashMint()

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -91,7 +91,7 @@ contract DssFlash {
         uint256 fee = mul(_amount, toll) / WAD;
         uint256 bal = vat.dai(address(this));
 
-        IFlashMintReceiver(_receiver).execute(_amount, fee, _data);
+        IFlashMintReceiver(_receiver).onFlashMint(_amount, fee, _data);
 
         uint256 frad = rad(fee);
         require(vat.dai(address(this)) == add(bal, add(arad, frad)), "DssFlash/invalid-payback");

--- a/src/interface/IFlashMintReceiver.sol
+++ b/src/interface/IFlashMintReceiver.sol
@@ -5,6 +5,6 @@ interface IFlashMintReceiver {
     /**
     * Must transfer _amount + _fee back to the flash mint contract when complete.
     */
-    function execute(uint256 _amount, uint256 _fee, bytes calldata _params) external;
+    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata _params) external;
 
 }


### PR DESCRIPTION
This change was brought up [here](https://forum.makerdao.com/t/mip25-flash-mint-module/4400/8), and I support the reasoning behind it.