### PR TITLE
refactor: make vat and vow immutable to save gas

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -21,11 +21,11 @@ contract DssFlash {
     }
 
     // --- Data ---
-    VatLike public  vat;    // CDP Engine
-    address public  vow;    // Debt Engine
-    uint256 public  line;   // Debt Ceiling  [rad]
-    uint256 public  toll;   // Fee           [wad]
-    uint256 private locked; // reentrancy guard
+    VatLike public immutable  vat;    // CDP Engine
+    address public immutable  vow;    // Debt Engine
+    uint256 public  line;             // Debt Ceiling  [rad]
+    uint256 public  toll;             // Fee           [wad]
+    uint256 private locked;           // reentrancy guard
 
     // --- Events ---
     event Rely(address indexed usr);
@@ -42,10 +42,11 @@ contract DssFlash {
     }
 
     // --- Init ---
-    constructor(address _vat) public {
+    constructor(address _vat, address _vow) public {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
         vat = VatLike(_vat);
+        vow = _vow;
     }
 
     // --- Math ---
@@ -64,11 +65,6 @@ contract DssFlash {
     }
 
     // --- Administration ---
-    function file(bytes32 what, address addr) external auth {
-        if (what == "vow") vow = addr;
-        else revert("DssFlash/file-unrecognized-param");
-        emit File(what, addr);
-    }
     function file(bytes32 what, uint256 data) external auth {
         if (what == "line") line = data;
         else if (what == "toll") toll = data;

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -219,9 +219,9 @@ contract DssFlashTest is DSTest {
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
 
-        flash = new DssFlash(address(vat));
-
         vow = new TestVow(address(vat), address(0), address(0));
+
+        flash = new DssFlash(address(vat), address(vow));
 
         gold = new DSToken("GEM");
         gold.mint(1000 ether);
@@ -257,7 +257,6 @@ contract DssFlashTest is DSTest {
         assertEq(vat.dai(me), rad(100 ether));
 
         // Basic auth and 1000 ether debt ceiling
-        flash.file("vow", address(vow));
         flash.file("line", rad(1000 ether));
         vat.rely(address(flash));
 


### PR DESCRIPTION
Closes https://github.com/hexonaut/dss-flash/issues/12

DssFlash is stateless other than the admin params, so we can easily redeploy if `vow` changes.