### PR TITLE
opt: allow flash minting 0 dai

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -84,7 +84,6 @@ contract DssFlash {
     ) external lock {
         uint256 arad = rad(_amount);
 
-        require(arad > 0, "DssFlash/amount-zero");
         require(arad <= line, "DssFlash/ceiling-exceeded");
 
         vat.suck(address(this), _receiver, arad);

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -274,8 +274,8 @@ contract DssFlashTest is DSTest {
         flash.mint(address(immediatePaybackReceiver), 10 ether, "");
     }
 
-    // test mint() for_amount <= 0
-    function testFail_mint_zero_amount () public {
+    // test mint() for _amount == 0
+    function test_mint_zero_amount () public {
         flash.mint(address(immediatePaybackReceiver), 0, "");
     }
 


### PR DESCRIPTION
Minting 0 doesn't break any logic, and the check costs a bit of gas + string storage. All else being equal I think it is okay to remove this.