### PR TITLE
feat: add msg.sender to onFlashMint()

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -92,7 +92,7 @@ contract DssFlash {
         uint256 fee = mul(_amount, toll) / WAD;
         uint256 bal = vat.dai(address(this));
 
-        IFlashMintReceiver(_receiver).onFlashMint(_amount, fee, _data);
+        IFlashMintReceiver(_receiver).onFlashMint(msg.sender, _amount, fee, _data);
 
         uint256 frad = rad(fee);
         require(vat.dai(address(this)) == add(bal, add(arad, frad)), "DssFlash/invalid-payback");

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -47,7 +47,7 @@ contract TestImmediatePaybackReceiver is FlashMintReceiverBase {
     constructor(address _flash, address _vat) FlashMintReceiverBase(_flash, _vat) public {
     }
 
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override {
         // Just pay back the original amount
         payBackFunds(_amount, _fee);
     }
@@ -66,7 +66,7 @@ contract TestMintAndPaybackReceiver is FlashMintReceiverBase {
         mint = _mint;
     }
 
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override {
         TestVat _vat = TestVat(address(vat));
         _vat.mint(address(this), rad(mint));
 
@@ -87,7 +87,7 @@ contract TestMintAndPaybackAllReceiver is FlashMintReceiverBase {
         mint = _mint;
     }
 
-    function onFlashMint(uint256 _amount, uint256, bytes calldata) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256, bytes calldata) external override {
         TestVat _vat = TestVat(address(vat));
         _vat.mint(address(this), rad(mint));
 
@@ -102,7 +102,7 @@ contract TestMintAndPaybackDataReceiver is FlashMintReceiverBase {
     constructor(address _flash, address _vat) FlashMintReceiverBase(_flash, _vat) public {
     }
 
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata _data) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata _data) external override {
         (uint256 mintAmount) = abi.decode(_data, (uint256));
         TestVat _vat = TestVat(address(vat));
         _vat.mint(address(this), rad(mintAmount));
@@ -121,7 +121,7 @@ contract TestReentrancyReceiver is FlashMintReceiverBase {
         immediatePaybackReceiver = new TestImmediatePaybackReceiver(_flash, _vat);
     }
 
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata _data) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata _data) external override {
         flash.mint(address(immediatePaybackReceiver), _amount + _fee, _data);
 
         payBackFunds(_amount, _fee);
@@ -146,7 +146,7 @@ contract TestDEXTradeReceiver is FlashMintReceiverBase {
         ilk = ilk_;
     }
 
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata) external override {
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override {
         address me = address(this);
         uint256 totalDebt = _amount + _fee;
         uint256 goldAmount = totalDebt * 3;

--- a/src/interface/IFlashMintReceiver.sol
+++ b/src/interface/IFlashMintReceiver.sol
@@ -5,6 +5,6 @@ interface IFlashMintReceiver {
     /**
     * Must transfer _amount + _fee back to the flash mint contract when complete.
     */
-    function onFlashMint(uint256 _amount, uint256 _fee, bytes calldata _params) external;
+    function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata _params) external;
 
 }


### PR DESCRIPTION
Closes https://github.com/hexonaut/dss-flash/issues/11

Forward the `msg.sender` for security on the receiving contract.

This is very useful for the common pattern of:

```
// Initializing priveleged function
function init() auth {
	flash.mint(address(this), amount, data);
}

function onFlashMint(address _sender, uint256 _amount, uint256 _fee, bytes calldata _params) external {
	require(msg.sender == address(flash) && _sender == address(this));

	// We are now confident that this flash loan was initiated by the init() function above
}
```