### PR TITLE
Cleanup

### DIFF
--- a/src/flash.sol
+++ b/src/flash.sol
@@ -37,7 +37,7 @@ interface VatLike {
     function dai(address) external view returns (uint256);
     function move(address, address, uint256) external;
     function heal(uint256) external;
-    function suck(address,address,uint256) external;
+    function suck(address, address, uint256) external;
 }
 
 contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {

--- a/src/flash.sol
+++ b/src/flash.sol
@@ -183,7 +183,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
         );
 
         vat.heal(amount);
-        require(vat.dai(address(this)) >= add(prev, fee), "DssFlash/insufficient-fee");
+        require(vat.dai(address(this)) >= _add(prev, fee), "DssFlash/insufficient-fee");
 
         return true;
     }

--- a/src/flash.sol
+++ b/src/flash.sol
@@ -18,7 +18,6 @@ pragma solidity 0.6.12;
 
 import "./interface/IERC3156FlashLender.sol";
 import "./interface/IERC3156FlashBorrower.sol";
-import "./interface/IVatDaiFlashBorrower.sol";
 import "./interface/IVatDaiFlashLender.sol";
 
 interface DaiLike {
@@ -57,7 +56,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
     DaiJoinLike public immutable daiJoin;
     DaiLike     public immutable dai;
     address     public immutable vow;       // vow intentionally set immutable to save gas
-    
+
     uint256              public line;       // Debt Ceiling  [wad]
     uint256              public toll;       // Fee           [wad = 100%]
     uint256           private locked;       // Reentrancy guard
@@ -154,7 +153,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
             receiver.onFlashLoan(msg.sender, token, amount, fee, data) == CALLBACK_SUCCESS,
             "DssFlash/callback-failed"
         );
-        
+
         dai.transferFrom(address(receiver), address(this), total);
         daiJoin.join(address(this), total);
         vat.heal(rad);

--- a/src/flash.sol
+++ b/src/flash.sol
@@ -96,10 +96,10 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
     uint256 constant WAD = 10 ** 18;
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
     }
-    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
 
@@ -129,7 +129,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
     ) external override view returns (uint256) {
         require(token == address(dai), "DssFlash/token-unsupported");
 
-        return mul(amount, toll) / WAD;
+        return _mul(amount, toll) / WAD;
     }
     function flashLoan(
         IERC3156FlashBorrower receiver,
@@ -140,9 +140,9 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
         require(token == address(dai), "DssFlash/token-unsupported");
         require(amount <= line, "DssFlash/ceiling-exceeded");
 
-        uint256 amt = mul(amount, RAY);
-        uint256 fee = mul(amount, toll) / WAD;
-        uint256 total = add(amount, fee);
+        uint256 amt = _mul(amount, RAY);
+        uint256 fee = _mul(amount, toll) / WAD;
+        uint256 total = _add(amount, fee);
 
         vat.suck(address(this), address(this), amt);
         daiJoin.exit(address(receiver), amount);
@@ -157,7 +157,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
         dai.transferFrom(address(receiver), address(this), total);
         daiJoin.join(address(this), total);
         vat.heal(amt);
-        vat.move(address(this), vow, mul(fee, RAY));
+        vat.move(address(this), vow, _mul(fee, RAY));
 
         return true;
     }
@@ -168,9 +168,9 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
         uint256 amount,                         // amount to flash loan [rad]
         bytes calldata data                     // arbitrary data to pass to the receiver
     ) external override lock returns (bool) {
-        require(amount <= mul(line, RAY), "DssFlash/ceiling-exceeded");
+        require(amount <= _mul(line, RAY), "DssFlash/ceiling-exceeded");
 
-        uint256 fee = mul(amount, toll) / WAD;
+        uint256 fee = _mul(amount, toll) / WAD;
 
         vat.suck(address(this), address(receiver), amount);
 

--- a/src/flash.sol
+++ b/src/flash.sol
@@ -140,11 +140,11 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
         require(token == address(dai), "DssFlash/token-unsupported");
         require(amount <= line, "DssFlash/ceiling-exceeded");
 
-        uint256 rad = mul(amount, RAY);
+        uint256 amt = mul(amount, RAY);
         uint256 fee = mul(amount, toll) / WAD;
         uint256 total = add(amount, fee);
 
-        vat.suck(address(this), address(this), rad);
+        vat.suck(address(this), address(this), amt);
         daiJoin.exit(address(receiver), amount);
 
         emit FlashLoan(address(receiver), token, amount, fee);
@@ -156,7 +156,7 @@ contract DssFlash is IERC3156FlashLender, IVatDaiFlashLender {
 
         dai.transferFrom(address(receiver), address(this), total);
         daiJoin.join(address(this), total);
-        vat.heal(rad);
+        vat.heal(amt);
         vat.move(address(this), vow, mul(fee, RAY));
 
         return true;

--- a/src/flash.t.sol
+++ b/src/flash.t.sol
@@ -63,11 +63,13 @@ contract TestDoNothingReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token; _amount; _fee;
         // Don't do anything
         return CALLBACK_SUCCESS;
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _amount; _fee;
         // Don't do anything
         return CALLBACK_SUCCESS_VAT_DAI;
     }
@@ -81,6 +83,7 @@ contract TestImmediatePaybackReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token;
         // Just pay back the original amount
         approvePayback(add(_amount, _fee));
 
@@ -88,6 +91,7 @@ contract TestImmediatePaybackReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender;
         // Just pay back the original amount
         payBackVatDai(add(_amount, _fee));
 
@@ -109,6 +113,7 @@ contract TestLoanAndPaybackReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token;
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
         flash.vat().hope(address(flash.daiJoin()));
         flash.daiJoin().exit(address(this), mint);
@@ -119,6 +124,7 @@ contract TestLoanAndPaybackReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender;
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
 
         payBackVatDai(add(_amount, _fee));
@@ -141,6 +147,7 @@ contract TestLoanAndPaybackAllReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token; _fee;
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
         flash.vat().hope(address(flash.daiJoin()));
         flash.daiJoin().exit(address(this), mint);
@@ -151,6 +158,7 @@ contract TestLoanAndPaybackAllReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _fee;
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
 
         payBackVatDai(add(_amount, rad(mint)));
@@ -167,6 +175,7 @@ contract TestLoanAndPaybackDataReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata _data) external override returns (bytes32) {
+        _sender; _token;
         (uint256 mint) = abi.decode(_data, (uint256));
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
         flash.vat().hope(address(flash.daiJoin()));
@@ -178,6 +187,7 @@ contract TestLoanAndPaybackDataReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata _data) external override returns (bytes32) {
+        _sender;
         (uint256 mint) = abi.decode(_data, (uint256));
         TestVat(address(flash.vat())).mint(address(this), rad(mint));
 
@@ -198,6 +208,7 @@ contract TestReentrancyReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata _data) external override returns (bytes32) {
+        _sender;
         flash.flashLoan(immediatePaybackReceiver, _token, _amount + _fee, _data);
 
         approvePayback(add(_amount, _fee));
@@ -206,6 +217,7 @@ contract TestReentrancyReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata _data) external override returns (bytes32) {
+        _sender;
         flash.vatDaiFlashLoan(immediatePaybackReceiver, _amount + _fee, _data);
 
         payBackVatDai(add(_amount, _fee));
@@ -233,6 +245,7 @@ contract TestDEXTradeReceiver is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token;
         address me = address(this);
         uint256 totalDebt = _amount + _fee;
         uint256 goldAmount = totalDebt * 3;
@@ -254,6 +267,7 @@ contract TestDEXTradeReceiver is FlashLoanReceiverBase {
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata _data) external override returns (bytes32) {
+        _sender; _amount; _fee; _data;
         return CALLBACK_SUCCESS_VAT_DAI;
     }
 
@@ -268,12 +282,14 @@ contract TestBadReturn is FlashLoanReceiverBase {
     }
 
     function onFlashLoan(address _sender, address _token, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender; _token;
         approvePayback(add(_amount, _fee));
 
         return BAD_HASH;
     }
 
     function onVatDaiFlashLoan(address _sender, uint256 _amount, uint256 _fee, bytes calldata) external override returns (bytes32) {
+        _sender;
         payBackVatDai(add(_amount, _fee));
 
         return BAD_HASH;


### PR DESCRIPTION
* removes an unnecessary inheritance
* code cleanup
* fix shadowed declarations and other compiler warnings
* rename `rad` to `amt` to avoid confusion with `RAD`